### PR TITLE
Update TraceOn for latest runkit7 versions

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -192,7 +192,6 @@ return [
 
     // A list of files to include in analysis
     'file_list' => [
-        // 'vendor/phpunit/phpunit/src/Framework/TestCase.php',
     ],
 
     // A file list that defines files that will be excluded
@@ -216,7 +215,6 @@ return [
     // your application should be included in this list.
     'directory_list' => [
         'src',
-        'vendor',
     ],
 
     // List of case-insensitive file extensions supported by Phan.
@@ -235,9 +233,52 @@ return [
     //       should be added to the `directory_list` as
     //       to `exclude_analysis_directory_list`.
     "exclude_analysis_directory_list" => [
-        'vendor',
     ],
 
     // A list of plugin files to execute
-    'plugins' => [ ],
+    'plugins' => [
+        'AlwaysReturnPlugin',
+        'DollarDollarPlugin',
+        'UnreachableCodePlugin',
+        'DuplicateArrayKeyPlugin',
+        'PregRegexCheckerPlugin',
+        'PrintfCheckerPlugin',
+        'UseReturnValuePlugin',
+
+        // UnknownElementTypePlugin warns about unknown types in element signatures.
+        'UnknownElementTypePlugin',
+        'DuplicateExpressionPlugin',
+        // warns about carriage returns("\r"), trailing whitespace, and tabs in PHP files.
+        'WhitespacePlugin',
+        // Warn about inline HTML anywhere in the files.
+        'InlineHTMLPlugin',
+        ////////////////////////////////////////////////////////////////////////
+        // Plugins for Phan's self-analysis
+        ////////////////////////////////////////////////////////////////////////
+
+        'NoAssertPlugin',
+        'PossiblyStaticMethodPlugin',
+
+        // 'HasPHPDocPlugin',
+        'PHPDocToRealTypesPlugin',  // suggests replacing (at)return void with `: void` in the declaration, etc.
+        'PHPDocRedundantPlugin',
+        'PreferNamespaceUsePlugin',
+        'EmptyStatementListPlugin',
+
+        // Report empty (not overridden or overriding) methods and functions
+        // 'EmptyMethodAndFunctionPlugin',
+
+        // This should only be enabled if the code being analyzed contains Phan plugins.
+        'PhanSelfCheckPlugin',
+        // Warn about using the same loop variable name as a loop variable of an outer loop.
+        'LoopVariableReusePlugin',
+        // Warn about assigning the value the variable already had to that variable.
+        'RedundantAssignmentPlugin',
+        // These are specific to Phan's coding style
+        'StrictComparisonPlugin',
+        // Warn about `$var == SOME_INT_OR_STRING_CONST` due to unintuitive behavior such as `0 == 'a'`
+        'StrictLiteralComparisonPlugin',
+        'ShortArrayPlugin',
+        'SimplifyExpressionPlugin',
+    ],
 ];

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: php
 php:
-  - 7.1
-  - 7.0
+  - 7.4
+  - 7.3
+  - 7.2
 
 before_script:
   - ci/install_runkit_for_php_version.sh
   - composer install
 
 script:
-  - php vendor/bin/phpunit tests
+  - vendor/bin/phan
+  - php -d opcache.enable=0 vendor/bin/phpunit tests

--- a/README.md
+++ b/README.md
@@ -11,15 +11,17 @@ This requires [runkit7 (fork of the runkit PECL)](https://github.com/runkit7/run
 Logging for parameters, return types, backtraces, and exceptions is enabled by default.
 Code using this utility can disable or replace the default implementation to log those details.
 
+**NOTE: When using this in recent php versions, disable opcache or opcache optimizations before running php.**
+
 ## Authors
 
 Tyson Andre
 
 ## Requirements
 
-- PHP version 7.0 or greater
-- [runkit7 (fork of runkit)](https://github.com/runkit7/runkit7) must be installed and enabled.
-- runkit must be enabled in your php.ini settings (`extension=runkit.so`)
+- PHP version 7.2 or greater
+- [runkit7](https://github.com/runkit7/runkit7) 3.1.0a1 or greater must be installed and enabled.
+- runkit7 must be enabled in your php.ini settings (`extension=runkit7.so`)
 
 ## License
 
@@ -107,7 +109,7 @@ To attempt this, `runkit.internal_override=On` must be temporarily added to php.
 
 -----
 
-README.md: Copyright 2017 Ifwe Inc.
+README.md: Copyright 2020 Ifwe Inc.
 
 README.md is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License.
 

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,12 @@
     "keywords": ["mocks", "debugging", "traceon", "runkit", "runkit7"],
     "type":    "library",
     "require": {
-        "php": ">= 7.0",
-        "ext-runkit": ">=1.0.5a5"
+        "php": ">= 7.2",
+        "ext-runkit7": ">=3.1.0a1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.2"
+        "phpunit/phpunit": "^7.0",
+        "phan/phan": "^3.1.1"
     },
     "autoload": {
         "psr-4": {"TraceOn\\": "src/TraceOn"}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,6 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          forceCoversAnnotation="false"
-         mapTestClassNameToCoveredClassName="false"
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"

--- a/tests/TraceOnTest.php
+++ b/tests/TraceOnTest.php
@@ -1,8 +1,9 @@
 <?php
 namespace TraceOn\Tests;
 
-use \PHPUnit\Framework\TestCase;
-use \TraceOn\TraceOn;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use TraceOn\TraceOn;
 
 function dummyGlobalFunction(string $arg) {
     return 'dummy' . 'GlobalFunction:' . $arg;
@@ -28,6 +29,13 @@ function dummyGlobalFunction(string $arg) {
  * limitations under the License.
  */
 class TraceOnTest extends TestCase {
+    public static function setUpBeforeClass(): void {
+        parent::setUpBeforeClass();
+        if (extension_loaded('Zend OPcache') && ini_get('opcache.enable') && ini_get('opcache.enable_cli')) {
+            throw new RuntimeException("TraceOn has known issues in some php versions when opcache optimizations are enabled - disable opcache");
+        }
+    }
+
     public function tearDown() {
         parent::tearDown();
         TraceOn::cleanup_all();


### PR DESCRIPTION
- Drop support for php <= 7.1
- Require runkit7 3.1.0a1 or 4.0+
- Add a note that opcache optimizations should be disabled when using
  runkit7 due to runkit7 making opcache's optimization assumptions
  unsafe.
- Run Phan, fix bug tracking which global functions were instrumented
  when there was more than one global function